### PR TITLE
Use ghc94 in shell.nix and align dependencies

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -1,11 +1,22 @@
 { pkgs ? import <nixpkgs> {} }:
 let
-  ghc = pkgs.haskell.packages.ghc92.ghcWithPackages
-          (p: [ p.random
-                p.monad-extras
+  ghc = pkgs.haskell.packages.ghc94.ghcWithPackages
+          (p: [ p.monad-extras
+                p.transformers
+                p.mtl
+                p.deepseq
+                p.containers
+                p.ghc-heap
+                p.megaparsec
+                p.vector
+                p.directory
+                p.filepath
+                p.bytestring
+                p.text
+                p.random
                 p.log-domain
                 p.statistics
-		p.megaparsec
+                p.array
               ]);
 in
 pkgs.mkShell {


### PR DESCRIPTION
## Summary
- Use `pkgs.haskell.packages.ghc94` in `shell.nix`
- Mirror all Haskell dependencies in the shell environment

## Testing
- `cabal build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*
- `ghc --version` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68ab3a226808833084303ac4b8a3ffdd