### PR TITLE
Fix package metadata and regenerate cabal file

### DIFF
--- a/chemalgprog.cabal
+++ b/chemalgprog.cabal
@@ -1,0 +1,80 @@
+cabal-version: 2.4
+name: chemalgprog
+version: 0.1.0.0
+synopsis: Chemical Algorithmic Programming
+description: A library for molecular representation and probabilistic programming.
+category: Development
+author: Oliver Goldstein
+maintainer: oliverjgoldstein@gmail.com, oliver.goldstein@cs.ox.ac.uk, sammarch2@gmail.com
+license: AGPL-3.0
+license-file: LICENSE.txt
+build-type: Simple
+extra-source-files:
+    CHANGELOG.md
+    README.md
+
+library
+    exposed-modules:
+        LazyPPL
+        Molecule
+        Constants
+        Distr
+        Coordinate
+        Group
+        Orbital
+        Parser
+        Reaction
+        Serialisable
+        TestInference
+    other-modules:
+        ExtraF
+        ParserSingle
+        LogPModel
+        Validator
+    hs-source-dirs:
+        src
+    default-language: Haskell2010
+    build-depends:
+        base >=4.13 && <4.21,
+        monad-extras,
+        transformers,
+        mtl,
+        deepseq,
+        containers,
+        ghc-heap,
+        megaparsec >=9.0 && <10.0,
+        vector,
+        directory,
+        filepath,
+        bytestring,
+        text,
+        random,
+        log-domain,
+        statistics,
+        array
+
+executable chemalgprog
+    main-is: Main.hs
+    hs-source-dirs:
+        app
+    default-language: Haskell2010
+    build-depends:
+        base >=4.13 && <4.21,
+        monad-extras,
+        transformers,
+        mtl,
+        deepseq,
+        containers,
+        ghc-heap,
+        megaparsec >=9.0 && <10.0,
+        vector,
+        directory,
+        filepath,
+        bytestring,
+        text,
+        random,
+        log-domain,
+        statistics,
+        array,
+        chemalgprog
+

--- a/package.yaml
+++ b/package.yaml
@@ -1,6 +1,5 @@
 name: chemalgprog
 version: 0.1.0.0
-<<<<<<< codex/reorganize-project-structure
 synopsis: Chemical Algorithmic Programming
 description: A library for molecular representation and probabilistic programming.
 category: Development
@@ -11,11 +10,6 @@ license-file: LICENSE.txt
 extra-source-files:
   - CHANGELOG.md
   - README.md
-
-=======
-author: Oliver Goldstein
-license: AGPL-3.0
->>>>>>> main
 dependencies:
   - base >= 4.13 && < 4.21
   - monad-extras
@@ -36,11 +30,7 @@ dependencies:
   - array
 
 library:
-<<<<<<< codex/reorganize-project-structure
   source-dirs: src
-=======
-  source-dirs: .
->>>>>>> main
   exposed-modules:
     - LazyPPL
     - Molecule
@@ -52,24 +42,18 @@ library:
     - Parser
     - Reaction
     - Serialisable
-<<<<<<< codex/reorganize-project-structure
     - TestInference
   other-modules:
     - ExtraF
     - ParserSingle
     - LogPModel
     - Validator
-=======
   default-language: Haskell2010
->>>>>>> main
 
 executables:
   chemalgprog:
     main: Main.hs
     source-dirs: app
-<<<<<<< codex/reorganize-project-structure
     dependencies:
       - chemalgprog
-=======
     default-language: Haskell2010
->>>>>>> main


### PR DESCRIPTION
## Summary
- resolve merge conflicts in package.yaml and clarify package metadata
- recreate chemalgprog.cabal to match updated configuration

## Testing
- `hpack` *(fails: command not found)*
- `stack build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab3de1d0a4833087caa86c65a9762b