### PR TITLE
Clarify license specification

### DIFF
--- a/chemalgprog.cabal
+++ b/chemalgprog.cabal
@@ -6,7 +6,7 @@ description: A library for molecular representation and probabilistic programmin
 category: Development
 author: Oliver Goldstein
 maintainer: oliverjgoldstein@gmail.com, oliver.goldstein@cs.ox.ac.uk, sammarch2@gmail.com
-license: AGPL-3.0
+license: AGPL-3.0-only
 license-file: LICENSE.txt
 build-type: Simple
 extra-source-files:

--- a/package.yaml
+++ b/package.yaml
@@ -5,7 +5,7 @@ description: A library for molecular representation and probabilistic programmin
 category: Development
 author: Oliver Goldstein
 maintainer: oliverjgoldstein@gmail.com, oliver.goldstein@cs.ox.ac.uk, sammarch2@gmail.com
-license: AGPL-3.0
+license: AGPL-3.0-only
 license-file: LICENSE.txt
 extra-source-files:
   - CHANGELOG.md


### PR DESCRIPTION
## Summary
- specify AGPL-3.0-only license in package.yaml and generated cabal file

## Testing
- `hpack` (command not found)
- `stack build` (command not found; attempted install failed with 403)

------
https://chatgpt.com/codex/tasks/task_e_68ab408a955883308772bd83cb3474f1