### PR TITLE
Upgrade to GHC 9.6

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -1,6 +1,6 @@
 { pkgs ? import <nixpkgs> {} }:
 let
-  ghc = pkgs.haskell.packages.ghc94.ghcWithPackages
+  ghc = pkgs.haskell.packages.ghc96.ghcWithPackages
           (p: [ p.monad-extras
                 p.transformers
                 p.mtl

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,3 +1,3 @@
-resolver: lts-21.24
+resolver: lts-22.25
 packages:
   - .


### PR DESCRIPTION
## Summary
- Move Stack resolver to `lts-22.25` to target GHC 9.6
- Update Nix shell to use `ghc96`

## Testing
- `stack build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed / 403)*

------
https://chatgpt.com/codex/tasks/task_e_68ab45ccc52c8330a5c11312ff099d6f