### PR TITLE
Use pretty printer for sampled molecules

### DIFF
--- a/src/TestInference.hs
+++ b/src/TestInference.hs
@@ -134,5 +134,6 @@ main = do
       putStrLn "Observed molecule is valid. Proceeding with sampling..."
       samples <- mh 0.1 (moleculeModel validObserved)
       let (molecules, weights) = unzip $ take 1000 $ drop 1000 samples
-      putStrLn $ "Sampled molecules: " ++ show molecules
+      putStrLn "Sampled molecules:"
+      mapM_ (putStrLn . prettyPrintMolecule) molecules
       putStrLn $ "Weights: " ++ show weights


### PR DESCRIPTION
## Summary
- print sampled molecules using `prettyPrintMolecule` for clearer formatting

## Testing
- `stack test` *(fails: command not found)*
- `apt-get update` *(fails: repository 403 errors, unable to install stack)*

------
https://chatgpt.com/codex/tasks/task_e_68ab48db694883308e6db7c44603c2e7