### PR TITLE
Use pure in Prob Applicative and remove deprecated return

### DIFF
--- a/src/LazyPPL.hs
+++ b/src/LazyPPL.hs
@@ -59,14 +59,18 @@ uniform = Prob $ \(Tree r _) -> r
 -- | Probabilities for a monad.
 -- | Sequencing is done by splitting the tree
 -- | and using different bits for different computations.
+instance Functor Prob where
+  fmap = liftM
+
+instance Applicative Prob where
+  pure a = Prob $ const a
+  (<*>) = ap
+
 instance Monad Prob where
-  return a = Prob $ const a
   (Prob m) >>= f = Prob $ \g ->
     let (g1, g2) = splitTree g
         (Prob m') = f (m g1)
     in m' g2
-instance Functor Prob where fmap = liftM
-instance Applicative Prob where {pure = return ; (<*>) = ap}
 
 {- | An unnormalized measure is represented by a probability distribution over pairs of a weight and a result -}
 newtype Meas a = Meas (WriterT (Product (Log Double)) Prob a)


### PR DESCRIPTION
## Summary
- define `pure` for `Prob`'s `Applicative` instance and rely on default `return`
- reorder `Functor`, `Applicative`, and `Monad` instances for clarity

## Testing
- `stack build` *(fails: command not found)*
- `apt-get update` *(fails: repository 403 while attempting to install stack)*

------
https://chatgpt.com/codex/tasks/task_e_68ab89b698948330a8de2711cf697200