### PR TITLE
Add Slater type orbital model

### DIFF
--- a/chemalgprog.cabal
+++ b/chemalgprog.cabal
@@ -28,6 +28,7 @@ library
         Coordinate
         Group
         Orbital
+        SlaterTypeOrbital
         Parser
         Reaction
         Serialisable

--- a/package.yaml
+++ b/package.yaml
@@ -39,6 +39,7 @@ library:
     - Coordinate
     - Group
     - Orbital
+    - SlaterTypeOrbital
     - Parser
     - Reaction
     - Serialisable

--- a/src/SlaterTypeOrbital.hs
+++ b/src/SlaterTypeOrbital.hs
@@ -1,0 +1,48 @@
+module SlaterTypeOrbital where
+
+import Orbital (PureOrbital(..))
+import Coordinate
+import LazyPPL (Prob, Meas, sample)
+import Distr (gamma, uniformbounded)
+
+-- | A Slater Type Orbital parameterised by principal quantum number,
+-- effective charge and angular component.
+data SlaterTypeOrbital = SlaterTypeOrbital
+  { stoPrincipalQuantumNumber :: Int
+  , stoZeta                   :: Double
+  , stoAngularComponent       :: PureOrbital
+  } deriving (Show, Eq, Read)
+
+-- | Normalisation constant for the radial part of the STO.
+normConstant :: SlaterTypeOrbital -> Double
+normConstant (SlaterTypeOrbital n z _) =
+  let fact = fromIntegral (product [1 .. 2 * n])
+  in (2 * z) ** (fromIntegral n + 0.5) / sqrt fact
+
+-- | Radial part of the STO wavefunction.
+radialPart :: SlaterTypeOrbital -> Double -> Double
+radialPart sto@(SlaterTypeOrbital n z _) r =
+  normConstant sto * r ** fromIntegral (n - 1) * exp (-z * r)
+
+-- | Radial probability density @r^2 |R(r)|^2@.
+radialPdf :: SlaterTypeOrbital -> Double -> Double
+radialPdf sto r =
+  let rp = radialPart sto r
+  in rp * rp * r * r
+
+-- | Sample a radial distance using the equivalence with the gamma distribution.
+sampleRadius :: SlaterTypeOrbital -> Prob Double
+sampleRadius (SlaterTypeOrbital n z _) =
+  gamma (fromIntegral (2 * n + 1)) (1 / (2 * z))
+
+-- | Sample a three-dimensional coordinate from the orbital assuming
+-- a uniform angular distribution.
+sampleCoordinate :: SlaterTypeOrbital -> Meas Coordinate
+sampleCoordinate sto = do
+  r <- sample $ sampleRadius sto
+  theta <- sample $ uniformbounded 0 (2 * pi)
+  phi <- sample $ uniformbounded 0 pi
+  let x = r * sin phi * cos theta
+      y = r * sin phi * sin theta
+      z = r * cos phi
+  return (Coordinate x y z)


### PR DESCRIPTION
## Summary
- add SlaterTypeOrbital module describing Slater-type orbitals
- expose SlaterTypeOrbital in package configuration

## Testing
- `stack build` *(fails: command not found)*
- `cabal build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac40c2863c8330a01f6447c9078343