### PR TITLE
Add benzene molecule example

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ The accompanying paper describes two illustrative experiments:
 
 Sample SDF files for these experiments are provided in `molecules/` and `logp/`.
 
+An example Haskell representation of a molecule is available in `src/Benzene.hs`, which defines the `benzene` structure programmatically.
+
 Author: Oliver Goldstein (oliverjgoldstein@gmail.com / oliver.goldstein@reuben.ox.ac.uk)
 
 ## License

--- a/chemalgprog.cabal
+++ b/chemalgprog.cabal
@@ -33,6 +33,7 @@ library
         Reaction
         Serialisable
         TestInference
+        Benzene
     other-modules:
         ExtraF
         ParserSingle

--- a/package.yaml
+++ b/package.yaml
@@ -44,6 +44,7 @@ library:
     - Reaction
     - Serialisable
     - TestInference
+    - Benzene
   other-modules:
     - ExtraF
     - ParserSingle

--- a/src/Benzene.hs
+++ b/src/Benzene.hs
@@ -1,0 +1,37 @@
+module Benzene where
+
+import Molecule
+import Coordinate
+import Constants (elementAttributes, elementShells)
+import qualified Data.Map as M
+
+benzene :: Molecule
+benzene = Molecule
+  { atoms =
+      [ Atom { atomID = i
+             , atomicAttr = elementAttributes sym
+             , coordinate = Coordinate x y z
+             , shells     = elementShells sym
+             }
+      | (i,sym,x,y,z) <- atomsData
+      ]
+  , bonds = M.fromList $ getSymmetricBonds
+      [ ((1,2), ring), ((2,3), ring), ((3,4), ring)
+      , ((4,5), ring), ((5,6), ring), ((6,1), ring)
+      , ((1,7), single), ((2,8), single), ((3,9), single)
+      , ((4,10), single), ((5,11), single), ((6,12), single)
+      ]
+  }
+  where
+    ring   = Bond { delocNum = 6, atomIDs = Just [1..6] }
+    single = Bond { delocNum = 2, atomIDs = Nothing }
+
+atomsData :: [(Integer, AtomicSymbol, Double, Double, Double)]
+atomsData =
+  [ (1,C,-1.2131,-0.6884,0.0),  (2,C,-1.2028, 0.7064,0.0)
+  , (3,C,-0.0103,-1.3948,0.0),  (4,C, 0.0104, 1.3948,0.0)
+  , (5,C, 1.2028,-0.7063,0.0),  (6,C, 1.2131, 0.6884,0.0)
+  , (7,H,-2.1577,-1.2244,0.0),  (8,H,-2.1393, 1.2564,0.0)
+  , (9,H,-0.0184,-2.4809,0.0),  (10,H,0.0184, 2.4808,0.0)
+  , (11,H,2.1394,-1.2563,0.0),  (12,H,2.1577, 1.2245,0.0)
+  ]


### PR DESCRIPTION
## Summary
- add Haskell definition of benzene molecule
- expose Benzene module in package files and docs

## Testing
- `stack build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*
- `apt-get install -y haskell-stack` *(fails: unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68b1d5e0a1fc8330b8ad61472e9cab6f