### PR TITLE
Add molecule parsing example

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,14 @@ Sample SDF files for these experiments are provided in `molecules/` and `logp/`.
 
 An example Haskell representation of a molecule is available in `src/Benzene.hs`, which defines the `benzene` structure programmatically.
 
+The `examples/ParseMolecules.hs` program shows how to parse the provided `molecules/benzene.sdf` and `molecules/water.sdf` files:
+
+```bash
+stack exec parse-molecules
+```
+
+The example prints each molecule's `logS` value and structure using the library parsers.
+
 Author: Oliver Goldstein (oliverjgoldstein@gmail.com / oliver.goldstein@reuben.ox.ac.uk)
 
 ## License

--- a/chemalgprog.cabal
+++ b/chemalgprog.cabal
@@ -86,3 +86,28 @@ executable chemalgprog
         array,
         chemalgprog
 
+executable parse-molecules
+    main-is: ParseMolecules.hs
+    hs-source-dirs:
+        examples
+    default-language: Haskell2010
+    build-depends:
+        base >=4.13 && <4.21,
+        monad-extras,
+        transformers,
+        mtl,
+        deepseq,
+        containers,
+        ghc-heap,
+        megaparsec >=9.0 && <10.0,
+        vector,
+        directory,
+        filepath,
+        bytestring,
+        text,
+        random,
+        log-domain,
+        statistics,
+        array,
+        chemalgprog
+

--- a/examples/ParseMolecules.hs
+++ b/examples/ParseMolecules.hs
@@ -1,0 +1,24 @@
+module Main where
+
+import Parser (parseSDFFile)
+import Molecule (prettyPrintMolecule)
+import Text.Megaparsec (errorBundlePretty)
+
+-- | Simple example parsing the provided benzene and water SDF files.
+main :: IO ()
+main = do
+    putStrLn "Parsing benzene.sdf"
+    benzene <- parseSDFFile "molecules/benzene.sdf"
+    case benzene of
+        Left err -> putStrLn $ errorBundlePretty err
+        Right (mol, logS) -> do
+            putStrLn $ "logS: " ++ show logS
+            putStrLn $ prettyPrintMolecule mol
+
+    putStrLn "\nParsing water.sdf"
+    water <- parseSDFFile "molecules/water.sdf"
+    case water of
+        Left err -> putStrLn $ errorBundlePretty err
+        Right (mol, logS) -> do
+            putStrLn $ "logS: " ++ show logS
+            putStrLn $ prettyPrintMolecule mol

--- a/package.yaml
+++ b/package.yaml
@@ -59,3 +59,9 @@ executables:
     dependencies:
       - chemalgprog
     language: Haskell2010
+  parse-molecules:
+    main: ParseMolecules.hs
+    source-dirs: examples
+    dependencies:
+      - chemalgprog
+    language: Haskell2010


### PR DESCRIPTION
## Summary
- provide ParseMolecules example parsing benzene and water SDF files
- document example and wire it into package configuration

## Testing
- `stack test` *(fails: command not found)*
- `stack exec parse-molecules` *(fails: command not found)*
- `runghc -i src examples/ParseMolecules.hs` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b1d9b3f0d4833084f5dbe9c8d0d7a7