### PR TITLE
Expose ParserSingle module for parsing examples

### DIFF
--- a/chemalgprog.cabal
+++ b/chemalgprog.cabal
@@ -34,9 +34,9 @@ library
         Serialisable
         TestInference
         Benzene
+        ParserSingle
     other-modules:
         ExtraF
-        ParserSingle
         LogPModel
         Validator
     hs-source-dirs:

--- a/package.yaml
+++ b/package.yaml
@@ -45,9 +45,9 @@ library:
     - Serialisable
     - TestInference
     - Benzene
+    - ParserSingle
   other-modules:
     - ExtraF
-    - ParserSingle
     - LogPModel
     - Validator
   language: Haskell2010


### PR DESCRIPTION
## Summary
- Expose `ParserSingle` from the library so example code can import `parseSDFFileNoLog`

## Testing
- ⚠️ `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b1e2bfd9b48330afaddc3681eb8af4